### PR TITLE
temporary fix per_page

### DIFF
--- a/lib/gitlab-fix-labels.js
+++ b/lib/gitlab-fix-labels.js
@@ -173,7 +173,7 @@ api.getProjectLabels = (projectId) =>
 {
     return request.andKeepRetrying(Object.assign({}, requestDefaults,
     {
-        url: api.uriFrag + `projects/${projectId}/labels`,
+        url: api.uriFrag + `projects/${projectId}/labels?per_page=100`,
     }));
 };
 


### PR DESCRIPTION
This is a temporary fix for per_page parameters #4 . 
requestDefaults per_page did not seems to work i can only add 20 labels. 